### PR TITLE
Fix API in production

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -63,7 +63,8 @@ module.exports = {
    ** See https://axios.nuxtjs.org/options
    */
   axios: {
-    debug: true
+    debug: true,
+    baseURL: process.env.BASE_URL || undefined
   },
   /*
    ** Auth module configuration


### PR DESCRIPTION
I believe i figured out the problem we were trying to fix yesterday. Axios requires you to set a base URL when not running from localhost. I set it up so it reads the base url from an environment variable called BASE_URL. I tested it in Heroku running in a Docker container.