### PR TITLE
Docker speed up

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -6,9 +6,9 @@ ARG BASE_URL
 
 WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
-COPY . /usr/src/app
+# COPY . /usr/src/app
 RUN npm install
-RUN npm run generate
+# RUN npm run generate
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 
 services:
   bluestar:

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -108,6 +108,9 @@ module.exports = {
           }
         })
       }
-    }
-  }
+    },
+    cache: true,
+    hardSource: true,
+    parallel: true,
+  },
 }


### PR DESCRIPTION
# Changes:
- docker-compose only builds once instead of twice
- Nuxt caches build artifacts, so subsequent builds are much faster